### PR TITLE
CommandLine.find() method was deprecated in selenium-3.3.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,8 +9,8 @@
   <url>http://gebish.org</url>
   <properties>
     <gebVersion>1.1.1</gebVersion>
-    <seleniumVersion>3.0.1</seleniumVersion>
-    <groovyVersion>2.4.7</groovyVersion>
+    <seleniumVersion>3.3.1</seleniumVersion>
+    <groovyVersion>2.4.11</groovyVersion>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
   </properties>

--- a/src/test/resources/GebConfig.groovy
+++ b/src/test/resources/GebConfig.groovy
@@ -5,7 +5,7 @@
 */
 import org.openqa.selenium.chrome.ChromeDriver
 import org.openqa.selenium.chrome.ChromeDriverService
-import org.openqa.selenium.os.CommandLine
+import org.openqa.selenium.os.ExecutableFinder
 
 import static org.apache.commons.lang3.SystemUtils.IS_OS_LINUX
 import static org.apache.commons.lang3.SystemUtils.IS_OS_MAC

--- a/src/test/resources/GebConfig.groovy
+++ b/src/test/resources/GebConfig.groovy
@@ -11,7 +11,10 @@ import static org.apache.commons.lang3.SystemUtils.IS_OS_LINUX
 import static org.apache.commons.lang3.SystemUtils.IS_OS_MAC
 
 File findDriverExecutable() {
-    def defaultExecutable = CommandLine.find("chromedriver")
+    /**
+     * CommandLine.find method was deprecated in selenium 3.3.1
+     */
+    def defaultExecutable = new ExecutableFinder().find("chromedriver")
     if (defaultExecutable) {
         new File(defaultExecutable)
     } else {


### PR DESCRIPTION
def defaultExecutable = CommandLine.find("chromedriver") 

to change

def defaultExecutable = new ExecutableFinder().find("chromedriver") 