### PR TITLE
update-dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,9 +8,9 @@
   <name>Geb Maven Example</name>
   <url>http://gebish.org</url>
   <properties>
-    <gebVersion>2.3</gebVersion>
-    <seleniumVersion>3.3.1</seleniumVersion>
-    <groovyVersion>2.4.11</groovyVersion>
+    <gebVersion>2.3.1</gebVersion>
+    <seleniumVersion>3.14.0</seleniumVersion>
+    <groovyVersion>2.4.16</groovyVersion>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
   </properties>
@@ -102,7 +102,7 @@
       <plugin>
       <groupId>com.github.webdriverextensions</groupId>
       <artifactId>webdriverextensions-maven-plugin</artifactId>
-      <version>3.1.1</version>
+      <version>3.1.3</version>
       <executions>
         <execution>
           <goals>
@@ -114,17 +114,17 @@
         <drivers>
           <driver>
             <name>chromedriver</name>
-            <version>2.27</version>
+            <version>2.45.0</version>
             <platform>mac</platform>
           </driver>
           <driver>
             <name>chromedriver</name>
-            <version>2.27</version>
+            <version>2.45.0</version>
             <platform>linux</platform>
           </driver>
           <driver>
             <name>chromedriver</name>
-            <version>2.27</version>
+            <version>2.45.0</version>
             <platform>windows</platform>
           </driver>
         </drivers>


### PR DESCRIPTION
Updated com.github.webdriverextension to the latest version, unfortunately, this plugin is out of date and not using the latest browsers driver versions. Also updated the other dependencies versions.